### PR TITLE
Tweaking the deployment script

### DIFF
--- a/.github/workflows/deploy-to-vm.yml
+++ b/.github/workflows/deploy-to-vm.yml
@@ -5,7 +5,10 @@ on:
     inputs:
       environment:
         required: true
-        type: environment
+        type: choice
+        options:
+        - development
+        - production
       port:
         required: true
         type: string

--- a/.github/workflows/deploy-to-vm.yml
+++ b/.github/workflows/deploy-to-vm.yml
@@ -3,6 +3,9 @@ name: Deploy application to VM
 on:
   workflow_call:
     inputs:
+      environment:
+        required: true
+        type: environment
       port:
         required: true
         type: string
@@ -23,7 +26,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    environment: production
+    environment: environment
 
     steps:
       - name: Checkout
@@ -33,37 +36,37 @@ jobs:
         run: |
           env
           mkdir -p ~/.ssh
-          echo "${{ secrets.ssh_key }}" > ~/.ssh/oracle
-          chmod 600 ~/.ssh/oracle
+          echo "${{ secrets.ssh_key }}" > ~/.ssh/vm
+          chmod 600 ~/.ssh/vm
           ssh-keyscan -p 22 -t ed25519 ${{ secrets.host }} >> ~/.ssh/known_hosts
 
       - name: Stop the app and clean up
         run: |
-          ssh -i ~/.ssh/oracle "ubuntu@${{ secrets.host }}" << END
+          ssh -i ~/.ssh/vm "ubuntu@${{ secrets.host }}" << END
             screen -XS auspak_${{ inputs.port }} quit
-            rm -rf ~/auspak
-            mkdir ~/auspak
+            rm -rf ~/auspak_${{ inputs.port }}
+            mkdir ~/auspak_${{ inputs.port }}
           END
 
       - name: Push repo to the host
         run: |
-          scp -i ~/.ssh/oracle -r ./* "ubuntu@${{ secrets.host }}:/home/ubuntu/auspak"
+          scp -i ~/.ssh/vm -r ./* "ubuntu@${{ secrets.host }}:/home/ubuntu/auspak_${{ inputs.port }}"
 
       - name: Set up dependencies
         run: |
-          ssh -i ~/.ssh/oracle "ubuntu@${{ secrets.host }}" << END
-            python3 -m venv ~/auspak/venv
-            source ~/auspak/venv/bin/activate
-            python3 -m pip install --upgrade pip
-            pip install -r ~/auspak/requirements.txt
+          ssh -i ~/.ssh/vm "ubuntu@${{ secrets.host }}" << END
+            python3.9 -m venv ~/auspak_${{ inputs.port }}/venv
+            source ~/auspak_${{ inputs.port }}/venv/bin/activate
+            python3.9 -m pip install --upgrade pip
+            pip install -r ~/auspak_${{ inputs.port }}/requirements.txt
           END
 
       - name: Run the app
         run: |
-          ssh -i ~/.ssh/oracle "ubuntu@${{ secrets.host }}" << END
+          ssh -i ~/.ssh/vm "ubuntu@${{ secrets.host }}" << END
             export SUPABASE_URL=${{ secrets.supabase_url }}
             export SUPABASE_KEY=${{ secrets.supabase_key }}
             screen -s "/bin/bash" -dmS auspak_${{ inputs.port }}
-            screen -S auspak_${{ inputs.port }} -X stuff "source ~/auspak/venv/bin/activate\n"
-            screen -S auspak_${{ inputs.port }} -X stuff "python3 ~/auspak/app.py --port ${{ inputs.port }}\n"
+            screen -S auspak_${{ inputs.port }} -X stuff "source ~/auspak_${{ inputs.port }}/venv/bin/activate\n"
+            screen -S auspak_${{ inputs.port }} -X stuff "python3.9 ~/auspak_${{ inputs.port }}/app.py --port ${{ inputs.port }}\n"
           END

--- a/.github/workflows/deploy-to-vm.yml
+++ b/.github/workflows/deploy-to-vm.yml
@@ -5,10 +5,7 @@ on:
     inputs:
       environment:
         required: true
-        type: choice
-        options:
-        - development
-        - production
+        type: string
       port:
         required: true
         type: string

--- a/.github/workflows/on-pr-commit.yml
+++ b/.github/workflows/on-pr-commit.yml
@@ -8,6 +8,7 @@ jobs:
   deploy-to-dev:
     uses: ./.github/workflows/deploy-to-vm.yml
     with:
+      environment: development
       port: 8001
     secrets:
       ssh_key: ${{ secrets.ORACLE_SSH_KEY }}

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -8,6 +8,7 @@ jobs:
   deploy-to-prod:
     uses: ./.github/workflows/deploy-to-vm.yml
     with:
+      environment: production
       port: 8000
     secrets:
       ssh_key: ${{ secrets.ORACLE_SSH_KEY }}


### PR DESCRIPTION
Making the deployment script (hopefully) better:
1. Setting Python version to 3.9, since most of our development team uses this version locally
2. Fixing the bug with dev deployment showing up as prod deployment in git
3. Using separate folders for prod/dev deployment